### PR TITLE
Patch cmds and biz

### DIFF
--- a/content/backend/avp/index.md
+++ b/content/backend/avp/index.md
@@ -26,7 +26,7 @@ docker build -f ./docker/avp.Dockerfile -t pionwebrtc/ion:latest-avp .
 
 ##### 3. run ion-avp
 ```
-docker run -p -p 6063:6063/tcp --network host -v $PWD/configs/avp.toml:/configs/avp.toml pionwebrtc/ion:latest-avp
+docker run -p 6063:6063/tcp --network host -v $PWD/configs/avp.toml:/configs/avp.toml pionwebrtc/ion:latest-avp
 ```
 
 #### 2. Build and run with source code

--- a/content/backend/biz/index.md
+++ b/content/backend/biz/index.md
@@ -23,15 +23,25 @@ check nats and redis is running
 lsof -i:4222
 lsof -i:6379
 ```
-##### 2. build ion-biz
+##### 2. build ion-app-biz
 
 ```
-docker build -f ./docker/biz.Dockerfile -t pionwebrtc/ion:latest-biz .
+docker build -f ./docker/app-biz.Dockerfile -t pionwebrtc/ion:latest-app-biz .
+```
+##### 3. build ion-signal
+
+```
+docker build -f ./docker/signal.Dockerfile -t pionwebrtc/ion:latest-signal .
 ```
 
-##### 3. run ion-biz
+##### 4. run ion-app-biz
 ```
-docker run -p 5551:5551/tcp -p 6060:6060/tcp --network host -v $PWD/configs/biz.toml:/configs/biz.toml pionwebrtc/ion:latest-biz
+docker run -p 6060:6060/tcp --network host -v $PWD/configs/app-biz.toml:/configs/app-biz.toml pionwebrtc/ion:latest-app-biz
+```
+
+##### 5. run ion-signal
+```
+docker run -p 5551:5551/tcp --network host -v $PWD/configs/signal.toml:/configs/signal.toml pionwebrtc/ion:latest-signal
 ```
 
 #### 2. Build and run with source code

--- a/content/backend/islb/index.md
+++ b/content/backend/islb/index.md
@@ -31,7 +31,7 @@ docker build -f ./docker/islb.Dockerfile -t pionwebrtc/ion:latest-islb .
 
 ##### 3. run ion-islb
 ```
-docker run -p -p 6061:6061/tcp --network host -v $PWD/configs/islb.toml:/configs/islb.toml pionwebrtc/ion:latest-islb
+docker run -p 6061:6061/tcp --network host -v $PWD/configs/islb.toml:/configs/islb.toml pionwebrtc/ion:latest-islb
 ```
 
 #### 2. Build and run with source code


### PR DESCRIPTION
This pull request is to correct some commands and also to divide the biz commands into app-biz and signal for the new architecture.

Now that the signal server and business logic are separated, the backend docker commands are not updated in the documentation.
So I have added the required commands to launch the app-biz and signal containers separately.